### PR TITLE
Add a cli argument for overriding the locker branch

### DIFF
--- a/prune/cli.py
+++ b/prune/cli.py
@@ -20,6 +20,7 @@ import tempfile
 from urllib.parse import urlparse
 
 from compliance.utils.credentials import Config
+from compliance.config import get_config
 
 from ilcli import Command
 
@@ -35,6 +36,11 @@ class _CorePruneCommand(Command):
                 "the URL to the evidence locker repository, "
                 "as an example https://github.com/my-org/my-repo"
             ),
+        )
+        self.add_argument(
+            "--branch",
+            help="Branch name for locker repository",
+            default=False,
         )
         self.add_argument(
             "--creds",
@@ -88,6 +94,10 @@ class _CorePruneCommand(Command):
         gitconfig = None
         if args.git_config or args.git_config_file:
             gitconfig = args.git_config or json.loads(open(args.git_config_file).read())
+        if args.branch:
+            c = get_config()
+            c.load()
+            c.raw_config["locker"]["default_branch"] = args.branch
         # self.name drives the Locker push mode.
         #   - dry-run translates to locker no-push mode
         #   - push-remote translates to locker full-remote mode


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Provide an ability to override the default branch for the locker repository.

## Why

Because the prune command does not load the auditree.json config and we do not use the `master` branch anymore in any of our repositories.

## How

* Accept an optional `--branch` command line argument.

## Test


## Context

none.