### PR TITLE
Add --clone-shallow-since-days option for the locker

### DIFF
--- a/prune/cli.py
+++ b/prune/cli.py
@@ -106,7 +106,13 @@ class _CorePruneCommand(Command):
         # self.name drives the Locker push mode.
         #   - dry-run translates to locker no-push mode
         #   - push-remote translates to locker full-remote mode
-        locker_args = [args.locker, args.creds, self.name, gitconfig, args.clone_shallow_since_days]
+        locker_args = [
+            args.locker,
+            args.creds,
+            self.name,
+            gitconfig,
+            args.clone_shallow_since_days,
+        ]
         local_locker_path = None
         evidences = args.config
         if not evidences:
@@ -127,7 +133,9 @@ class _CorePruneCommand(Command):
         self.out(self.outro_msg)
         self._remove_locker(local_locker_path)
 
-    def _get_locker(self, repo, creds, mode, gitconfig=None, clone_shallow_since_days=None):
+    def _get_locker(
+        self, repo, creds, mode, gitconfig=None, clone_shallow_since_days=None
+    ):
         local_locker_path = f"{tempfile.gettempdir()}/prune"
         if os.path.isdir(local_locker_path):
             self.out("Local locker found...")

--- a/prune/cli.py
+++ b/prune/cli.py
@@ -38,6 +38,11 @@ class _CorePruneCommand(Command):
             ),
         )
         self.add_argument(
+            "--clone-shallow-since-days",
+            help="use shallow clone for the evidence locker repository",
+            type=int,
+        )
+        self.add_argument(
             "--branch",
             help="Branch name for locker repository",
             default=False,
@@ -101,7 +106,7 @@ class _CorePruneCommand(Command):
         # self.name drives the Locker push mode.
         #   - dry-run translates to locker no-push mode
         #   - push-remote translates to locker full-remote mode
-        locker_args = [args.locker, args.creds, self.name, gitconfig]
+        locker_args = [args.locker, args.creds, self.name, gitconfig, args.clone_shallow_since_days]
         local_locker_path = None
         evidences = args.config
         if not evidences:
@@ -122,7 +127,7 @@ class _CorePruneCommand(Command):
         self.out(self.outro_msg)
         self._remove_locker(local_locker_path)
 
-    def _get_locker(self, repo, creds, mode, gitconfig=None):
+    def _get_locker(self, repo, creds, mode, gitconfig=None, clone_shallow_since_days=None):
         local_locker_path = f"{tempfile.gettempdir()}/prune"
         if os.path.isdir(local_locker_path):
             self.out("Local locker found...")
@@ -131,13 +136,16 @@ class _CorePruneCommand(Command):
             f"Cloning local locker for {repo}.  Depending on the "
             "size of your locker, this may take a while..."
         )
-        return PruneLocker(
+        locker = PruneLocker(
             name="prune",
             repo_url=repo,
             creds=Config(creds),
             do_push=True if mode == "push-remote" else False,
             gitconfig=gitconfig,
         )
+        if clone_shallow_since_days is not None:
+            locker.clone_shallow_since_days = clone_shallow_since_days
+        return locker
 
     def _remove_locker(self, locker_path):
         self.out("Removing local locker...")


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Add option to configure `clone_shallow_since_days` option that's already supported in the locker class. 

## Why

Our evidence locker is too large to fully clone locally and it makes it extremely difficult to work with the prune command without this flag. 

## How

- Add a new command-line argument --clone-shallow-since-days to the _CorePruneCommand class. 
- Update the _get_locker method to accept an additional parameter clone_shallow_since_days.
- Pass the clone_shallow_since_days attribute of the PruneLocker instance if the clone_shallow_since_days argument is provided when creating the locker.

## Test

- Executed the prune command with no issues:

```
$ prune push-remote https://(private repo) --config-file ./prune.json --clone-shallow-since-days 1
This is an official run.  Remote locker will be updated...
Cloning local locker for https://(private repo).  Depending on the size of your locker, this may take a while...
Locker has been cloned...
Local locker location is /var/folders/zb/6h4wth3j3g3561s518fcy70r0000gn/T/prune

Evidence (private repo file).json removed by boris.urbanik@ibm.com, tombstone applied...

Evidence (private repo file).json removed by boris.urbanik@ibm.com, tombstone applied...
Remote locker was updated...
Removing local locker...
Local locker has been removed...
```

## Context

- https://github.com/ComplianceAsCode/auditree-prune/issues/9
